### PR TITLE
gradle: fix build & update cardinal components API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,8 @@ repositories {
     maven {
         url = "https://www.cursemaven.com"
     }
-    maven {
-        name = "Ladysnake Libs"
-        url = "https://dl.bintray.com/ladysnake/libs"
+    maven { 
+        url = "https://jitpack.io" 
     }
     maven {
         url "https://www.cursemaven.com"

--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,12 @@ minecraft {
 }
 
 repositories {
-    maven {
-        url = "https://www.cursemaven.com"
-    }
     maven { 
         url = "https://jitpack.io" 
+    }
+    maven {
+        name = "Ladysnake Mods"
+        url = "https://ladysnake.jfrog.io/artifactory/mods"
     }
     maven {
         url "https://www.cursemaven.com"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 
 # Required Dependencies
 	fabric_version=0.30.0+1.16
-	cca_version=2.7.9
+	cca_version=2.8.2
 
 # Optional Dependencies
 	rei_version=5.8.9


### PR DESCRIPTION
The build was failing because `cardinal components` dependencies couldn't be found.

I replaced bintray with working versions from jitpack & also added jfrog.io to be sure.

I also noticed that version `2.7.9` of cca is not available on jfrog, so I updated it to `2.8.2`